### PR TITLE
fix: disable overscrolling for svg

### DIFF
--- a/lib/src/web_svg_view.dart
+++ b/lib/src/web_svg_view.dart
@@ -52,6 +52,7 @@ class _SvgImageState extends State<SvgImage> {
     <style>
         body {
             margin: 0;
+            overflow: hidden;
         }
         svg {
             width: 100%;


### PR DESCRIPTION
元のプルリクがマージされるまで待つ。

svgがwebviewの中にあるので、webview内のbodyがスクロール可能だとiOSでスクロールできてしまう。
overflow: hidden にすることでそれを防ぐ。