### PR TITLE
feat: add background-color

### DIFF
--- a/lib/src/web_svg_view.dart
+++ b/lib/src/web_svg_view.dart
@@ -4,8 +4,14 @@ import 'package:webview_flutter/webview_flutter.dart';
 
 // ignore: must_be_immutable
 class SvgImage extends StatefulWidget {
-  SvgImage({super.key, required this.svgString, required this.onElementClick});
+  SvgImage({
+    super.key,
+    required this.svgString,
+    required this.onElementClick,
+    this.backgroundColor = Colors.white,
+  });
   String svgString;
+  Color backgroundColor;
   Function(String) onElementClick;
 
   @override
@@ -85,7 +91,12 @@ ${widget.svgString}
   ''';
     controller.loadHtmlString(svgSrc);
     return Scaffold(
-      body: WebViewWidget(controller: controller),
+      body: Container(
+        color: widget.backgroundColor,
+        child: WebViewWidget(
+          controller: controller,
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
SVGが表示されるまでの間真っ白な背景色が表示されてしまうため、背景色を設定できるようにした。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for customizing the background color behind SVG images, with a default of white. Users can now specify a preferred background color for improved visual integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->